### PR TITLE
Workaround for missing float64 pooling operations

### DIFF
--- a/tfscripts/compat/v1/pooling.py
+++ b/tfscripts/compat/v1/pooling.py
@@ -34,6 +34,14 @@ def pool3d(layer, ksize, strides, padding, pooling_type):
         The pooled output tensor.
     """
 
+    # tensorflow's pooling operations do not support float64, so
+    # use workaround with casting to float32 and then back again
+    if layer.dtype == tf.float64:
+        layer = tf.cast(layer, tf.float32)
+        was_float64 = True
+    else:
+        was_float64 = False
+
     # pool over depth, if necessary:
     if ksize[-1] != 1 or strides[-1] != 1:
         layer = pool_over_depth(layer,
@@ -70,6 +78,9 @@ def pool3d(layer, ksize, strides, padding, pooling_type):
                                          padding=padding)
             layer = (layer_avg + layer_max) / 2.
 
+    if was_float64:
+        layer = tf.cast(layer, tf.float64)
+
     return layer
 
 
@@ -96,6 +107,14 @@ def pool(layer, ksize, strides, padding, pooling_type):
     tf.Tensor
         The pooled output tensor.
     """
+
+    # tensorflow's pooling operations do not support float64, so
+    # use workaround with casting to float32 and then back again
+    if layer.dtype == tf.float64:
+        layer = tf.cast(layer, tf.float32)
+        was_float64 = True
+    else:
+        was_float64 = False
 
     # pool over depth, if necessary:
     if ksize[-1] != 1 or strides[-1] != 1:
@@ -138,6 +157,10 @@ def pool(layer, ksize, strides, padding, pooling_type):
             padding=padding,
         )
         layer = (layer_avg + layer_max) / 2.
+
+    if was_float64:
+        layer = tf.cast(layer, tf.float64)
+
     return layer
 
 

--- a/tfscripts/pooling.py
+++ b/tfscripts/pooling.py
@@ -34,6 +34,14 @@ def pool3d(layer, ksize, strides, padding, pooling_type):
         The pooled output tensor.
     """
 
+    # tensorflow's pooling operations do not support float64, so
+    # use workaround with casting to float32 and then back again
+    if layer.dtype == tf.float64:
+        layer = tf.cast(layer, tf.float32)
+        was_float64 = True
+    else:
+        was_float64 = False
+
     # pool over depth, if necessary:
     if ksize[-1] != 1 or strides[-1] != 1:
         layer = pool_over_depth(layer,
@@ -70,6 +78,9 @@ def pool3d(layer, ksize, strides, padding, pooling_type):
                                          padding=padding)
             layer = (layer_avg + layer_max) / 2.
 
+    if was_float64:
+        layer = tf.cast(layer, tf.float64)
+
     return layer
 
 
@@ -96,6 +107,14 @@ def pool2d(layer, ksize, strides, padding, pooling_type):
     tf.Tensor
         The pooled output tensor.
     """
+
+    # tensorflow's pooling operations do not support float64, so
+    # use workaround with casting to float32 and then back again
+    if layer.dtype == tf.float64:
+        layer = tf.cast(layer, tf.float32)
+        was_float64 = True
+    else:
+        was_float64 = False
 
     # pool over depth, if necessary:
     if ksize[-1] != 1 or strides[-1] != 1:
@@ -130,6 +149,10 @@ def pool2d(layer, ksize, strides, padding, pooling_type):
                                      strides=strides,
                                      padding=padding)
         layer = (layer_avg + layer_max) / 2.
+
+    if was_float64:
+        layer = tf.cast(layer, tf.float64)
+
     return layer
 
 


### PR DESCRIPTION
Tensorflow (versions <=2.4, others not tested) does not currently support float64 operations for max and average pooling, despite stating this in the documentation. As a workaround, we'll cast to float32, apply pooling, and cast back to float64.