### PR TITLE
Remove Trailing Comma - 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=44.0"]  # Note: unfortunately need python >=2.7
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,7 @@ authors = [
 maintainers = [
     { name = "Mirco Huennefeld", email = "mirco.huennefeld@tu-dortmund.de" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=2.7"  # Note: unfortunately need python >=2.7
 
 dependencies = ["numpy", "matplotlib", "tensorflow"]
 
@@ -48,7 +48,10 @@ version = {attr = "tfscripts.__version__"}
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+# technically, black does not support python2.
+# This is all python versions black knows of and gets
+# rid of the trailing comma bug
+target-version = ["py33", "py34", "py35", "py36", "py37", "py38", "py39", "py310", "py311"]
 
 [tool.ruff]
 # select = ["ALL"]
@@ -65,7 +68,7 @@ ignore = [
     "T20",    # flake8-print
     "TCH",    # flake8-type-checking
     "S101",   # assert-used
-    "F401",   # imported but unused. NOTE: sooner or later, we should not ignore this
+    "COM812", # trailing comma to not insert after **kwargs, which is a syntax error prior to py3.6
     ]
 line-length = 79
 target-version = "py38"

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function
 import unittest
 import numpy as np
 import tensorflow as tf
-from itertools import product
 
 from tfscripts import layers
 

--- a/tfscripts/compat/v1/__init__.py
+++ b/tfscripts/compat/v1/__init__.py
@@ -1,2 +1,3 @@
+# ruff: noqa: F401
 from tfscripts import __version__, __description__, __url__
 from tfscripts import FLOAT_PRECISION

--- a/tfscripts/compat/v1/hex/conv.py
+++ b/tfscripts/compat/v1/hex/conv.py
@@ -9,14 +9,12 @@ ToDo:
 
 from __future__ import division, print_function
 
-import numpy as np
 import tensorflow as tf
 
 # tfscripts.compat.v1 specific imports
 from tfscripts.compat.v1.weights import (
     new_weights,
     new_biases,
-    new_kernel_weights,
 )
 from tfscripts.compat.v1.hex.visual import print_hex_data
 from tfscripts.compat.v1.hex import rotation

--- a/tfscripts/compat/v1/hex/icecube.py
+++ b/tfscripts/compat/v1/hex/icecube.py
@@ -4,7 +4,6 @@ IceCube specific constants and functions
 
 from __future__ import division, print_function
 
-import numpy as np
 import tensorflow as tf
 
 # tfscripts.compat.v1 specific imports

--- a/tfscripts/compat/v1/hex/visual.py
+++ b/tfscripts/compat/v1/hex/visual.py
@@ -5,20 +5,16 @@ tfscripts.compat.v1 hexagonal convolution visualization functions
 from __future__ import division, print_function
 
 import numpy as np
-import tensorflow as tf
 import matplotlib
 
-try:
-    import _tkinter
-except ImportError:
+import importlib
+
+if not importlib.util.find_spec("_tkinter"):
     matplotlib.use("AGG")
 import matplotlib.pyplot as plt
 
 # tfscripts.compat.v1 specific imports
 from tfscripts.compat.v1.hex.rotation import get_rotated_corner_weights
-
-# constants
-from tfscripts.compat.v1 import FLOAT_PRECISION
 
 
 def print_hex_data(hex_data):

--- a/tfscripts/compat/v1/layers.py
+++ b/tfscripts/compat/v1/layers.py
@@ -11,7 +11,6 @@ import tensorflow as tf
 from tfscripts.compat.v1.weights import (
     new_weights,
     new_biases,
-    new_kernel_weights,
 )
 from tfscripts.compat.v1 import conv
 from tfscripts.compat.v1 import core
@@ -343,7 +342,6 @@ def new_conv_nd_layer(
     # Create new weights aka. filters with the given shape.
     if method.lower() == "convolution":
         if weights is None:
-            # weights = new_kernel_weights(shape=shape)
             weights = new_weights(shape=shape)
 
         # Create new biases, one for each filter.

--- a/tfscripts/conv.py
+++ b/tfscripts/conv.py
@@ -16,7 +16,7 @@ import numpy as np
 import tensorflow as tf
 
 # tfscripts specific imports
-from tfscripts.weights import new_weights, new_locally_connected_weights
+from tfscripts.weights import new_locally_connected_weights
 
 # constants
 from tfscripts import FLOAT_PRECISION

--- a/tfscripts/hex/conv.py
+++ b/tfscripts/hex/conv.py
@@ -10,7 +10,6 @@ ToDo:
 from __future__ import division, print_function
 
 import logging
-import numpy as np
 import tensorflow as tf
 
 # tfscripts specific imports

--- a/tfscripts/hex/icecube.py
+++ b/tfscripts/hex/icecube.py
@@ -4,7 +4,6 @@ IceCube specific constants and functions
 
 from __future__ import division, print_function
 
-import numpy as np
 import tensorflow as tf
 
 # tfscripts specific imports

--- a/tfscripts/hex/visual.py
+++ b/tfscripts/hex/visual.py
@@ -5,12 +5,11 @@ tfscripts hexagonal convolution visualization functions
 from __future__ import division, print_function
 
 import numpy as np
-import tensorflow as tf
 import matplotlib
 
-try:
-    import _tkinter
-except ImportError:
+import importlib
+
+if not importlib.util.find_spec("_tkinter"):
     matplotlib.use("AGG")
 import matplotlib.pyplot as plt
 

--- a/tfscripts/layers.py
+++ b/tfscripts/layers.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 
 # tfscripts specific imports
-from tfscripts.weights import new_weights, new_biases, new_kernel_weights
+from tfscripts.weights import new_weights, new_biases
 from tfscripts.weights import new_locally_connected_weights
 from tfscripts import conv
 from tfscripts import core
@@ -361,7 +361,6 @@ class ConvNdLayer(tf.Module):
         # Create new weights aka. filters with the given shape.
         if method.lower() == "convolution":
             if weights is None:
-                # weights = new_kernel_weights(shape=shape)
                 weights = new_weights(
                     shape=shape, float_precision=float_precision
                 )

--- a/tfscripts/model.py
+++ b/tfscripts/model.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import json
 import numpy as np
 import tensorflow as tf
 
@@ -272,7 +271,7 @@ class DenseNNGaussian(DenseNN):
         use_nth_fc_layer_as_input=None,
         min_sigma_value=1e-3,
         verbose=False,
-        **kwargs,
+        **kwargs
     ):
         """Gaussian Uncertainty NN (Dense NN Model)
 


### PR DESCRIPTION
Remove trailing comma after kwargs, remove uneeded imports, update setup to include older python version. We don't want to officially keep support for older python versions, but we also don't have to break it if we don't have to